### PR TITLE
Add unique index for reddit links

### DIFF
--- a/migrations/1596492986396-add-redditnames-unique-index.js
+++ b/migrations/1596492986396-add-redditnames-unique-index.js
@@ -1,0 +1,18 @@
+const {MongoClient} = require('mongodb');
+const config = require('../config');
+
+module.exports.up = async () => {
+	const mongoClient = new MongoClient(config.mongodb.url, {useUnifiedTopology: true});
+	await mongoClient.connect();
+	const db = mongoClient.db(config.mongodb.databaseName);
+
+	await db.collection('redditAccounts').createIndex({userID: 1, guildID: 1, redditName: 1}, {unique: true});
+};
+
+module.exports.down = async () => {
+	const mongoClient = new MongoClient(config.mongodb.url, {useUnifiedTopology: true});
+	await mongoClient.connect();
+	const db = mongoClient.db(config.mongodb.databaseName);
+
+	await db.collection('redditAccounts').dropIndex({userID: 1, guildID: 1, redditName: 1}, {unique: true});
+};

--- a/web/routes/verification.js
+++ b/web/routes/verification.js
@@ -24,7 +24,6 @@ module.exports = db => polka()
 
 		try {
 			// Check if the accounts are already linked and return early if so
-			// TODO: implement this from Mongo via a compound primary key
 			const existingLink = await db.collection('redditAccounts').findOne({
 				userID: discord.id,
 				guildID: request.params.guildID,


### PR DESCRIPTION
ORM-level logic enforcement is good. This will prevent duplicate entries from ever being introduced to the `redditAccounts` collection. Also fixes a `// TODO` which is good for my sanity.