### PR TITLE
Don't needlessly drop tables from migrations

### DIFF
--- a/migrations/1596302630862-add-guildid-to-redditaccounts.js
+++ b/migrations/1596302630862-add-guildid-to-redditaccounts.js
@@ -6,9 +6,8 @@ module.exports.up = async () => {
 	await mongoClient.connect();
 	const db = mongoClient.db(config.mongodb.databaseName);
 
-	await db.dropCollection('redditAccounts');
-
-	await db.createCollection('redditAccounts', {
+	await db.runCommand({
+		collMod: 'redditAccounts',
 		validator: {
 			$jsonSchema: {
 				bsonType: 'object',
@@ -34,5 +33,21 @@ module.exports.down = async () => {
 	await mongoClient.connect();
 	const db = mongoClient.db(config.mongodb.databaseName);
 
-	await db.dropCollection('redditAccounts');
+	await db.runCommand({
+		collMod: 'redditAccounts',
+		validator: {
+			$jsonSchema: {
+				bsonType: 'object',
+				required: ['userID', 'redditName'],
+				properties: {
+					userID: {
+						bsonType: 'string',
+					},
+					redditName: {
+						bsonType: 'string',
+					},
+				},
+			},
+		},
+	});
 };


### PR DESCRIPTION
For some reason I thought it would be smart to drop a table in a migration. This would result in irreversible data loss if the database needed to be migrated down for whatever reason.

We're still in very early development at this point and store very little data that matters, but this was still awful practice and it baffles me that anyone lets me work on internet systems.