### PR TITLE
monkeypatch fix for debug command, Geo1088/yuuko#49

### DIFF
--- a/bot/commands/debug.js
+++ b/bot/commands/debug.js
@@ -1,3 +1,10 @@
 // Allows executing arbitrary Javascript expressions in bot scope (owner-only).
 
 module.exports = require('yuuko/dist/commands/debug');
+
+// command sets the owner requirement but that requirement doesn't currently respect team members, yuuko bug, monkeypatch for now
+module.exports.requirements = {
+	custom (message, args, {client}) {
+		return client.app.owner.id === message.author.id || client.app.team.members.some(member => member.membership_state === 2 && member.user.id === message.author.id);
+	},
+};


### PR DESCRIPTION
since the prod app is owned by a team, https://github.com/Geo1088/yuuko#49 prevents anyone from using the debug command. Needs a fix in yuuko, but this is a temporary fix because I need this command now to troubleshoot a separate issue.