### PR TITLE
Ban improvements

### DIFF
--- a/bot/commands/moderation/ban.js
+++ b/bot/commands/moderation/ban.js
@@ -72,7 +72,7 @@ module.exports = new Command('ban', async (message, args, {db}) => {
 	};
 	try {
 		// Insert information to database
-		await db.collection('bans').insertOne(banRecord);
+		await db.collection('bans').insertOne(banRecord, {ignoreUndefined: true});
 	} catch (error) {
 		message.channel.createMessage(`Banned <@${member.id}>, but there was an error writing the ban to the database. Have a developer check the logs, this should not happen.`).catch(() => {});
 		log.error(error);

--- a/bot/commands/moderation/unban.js
+++ b/bot/commands/moderation/unban.js
@@ -1,0 +1,42 @@
+const log = require('another-logger')({label: 'command:unban'});
+const {Command} = require('yuuko');
+const {parseUser} = require('../../util/discord');
+
+module.exports = new Command('unban', async (message, args, {db}) => {
+	const [user] = await parseUser(args.join(' ').trim(), message.channel.guild);
+	if (!user) {
+		message.channel.createMessage("Couldn't tell who you mean. Use a user ID or direct mention (user#discrim won't work).").catch(() => {});
+		return;
+	}
+
+	// Unban from Discord
+	try {
+		message.channel.guild.unbanMember(user.id);
+	} catch (error) {
+		message.channel.createMessage('Couldn\'t unban from Discord. Is the user really banned? Do I have "Ban Members" permission?').catch(() => {});
+		return;
+	}
+
+	// update database to revoke all bans that might be active
+	try {
+		const now = new Date();
+		await Promise.all([
+			db.collection('bans').updateMany(
+				{userID: user.id, revokeDate: {$exists: false}, expirationDate: {$gt: now}},
+				{$set: {revokeDate: now}},
+			),
+			db.collection('bans').updateMany(
+				{userID: user.id, revokeDate: {$exists: false}, expirationDate: {$exists: false}},
+				{$set: {revokeDate: now}},
+			),
+		]);
+	} catch (error) {
+		log.error(error);
+		log.error('User:', user);
+		message.channel.createMessage(`Unbanned <@${user.id}>, but there was an error writing to the database. Have a developer check the logs, this should not happen.`).catch(() => {});
+		return;
+	}
+
+	// all good
+	message.channel.createMessage(`Unbanned <@${user.id}>.`);
+});

--- a/migrations/1597553486707-add-revokeDate-to-bans.js
+++ b/migrations/1597553486707-add-revokeDate-to-bans.js
@@ -1,0 +1,77 @@
+const {MongoClient} = require('mongodb');
+const config = require('../config');
+
+module.exports.up = async () => {
+	const mongoClient = new MongoClient(config.mongodb.url, {useUnifiedTopology: true});
+	await mongoClient.connect();
+	const db = mongoClient.db(config.mongodb.databaseName);
+
+	await db.command({
+		collMod: 'bans',
+		validator: {
+			$jsonSchema: {
+				bsonType: 'object',
+				required: ['userID', 'guildID', 'date', 'note'],
+				properties: {
+					userID: {
+						bsonType: 'string',
+					},
+					guildID: {
+						bsonType: 'string',
+					},
+					modID: {
+						bsonType: 'string',
+					},
+					date: {
+						bsonType: 'date',
+					},
+					expirationDate: {
+						bsonType: 'date',
+					},
+					revokeDate: {
+						bsonType: 'date',
+					},
+					note: {
+						bsonType: 'string',
+					},
+				},
+			},
+		},
+	});
+};
+
+module.exports.down = async () => {
+	const mongoClient = new MongoClient(config.mongodb.url, {useUnifiedTopology: true});
+	await mongoClient.connect();
+	const db = mongoClient.db(config.mongodb.databaseName);
+
+	await db.command({
+		collMod: 'bans',
+		validator: {
+			$jsonSchema: {
+				bsonType: 'object',
+				required: ['userID', 'guildID', 'date', 'note'],
+				properties: {
+					userID: {
+						bsonType: 'string',
+					},
+					guildID: {
+						bsonType: 'string',
+					},
+					modID: {
+						bsonType: 'string',
+					},
+					date: {
+						bsonType: 'date',
+					},
+					expirationDate: {
+						bsonType: 'date',
+					},
+					note: {
+						bsonType: 'string',
+					},
+				},
+			},
+		},
+	});
+};


### PR DESCRIPTION
Fixes a lingering issue with permabans I thought I got in #32, also adds an unban command and adds validation for ban `revokeDate` fields. This is used when a user is unbanned prematurely to indicate that the ban is no longer valid while keeping a record of when the ban was initially slated to expire.