### PR TITLE
Center verification box properly

### DIFF
--- a/web/frontend/views/Verify.vue
+++ b/web/frontend/views/Verify.vue
@@ -118,7 +118,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .account-box {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
`.account-box` styles were getting overridden by the default `.box` styles, not anymore