### PR TITLE
Added say edit command

### DIFF
--- a/bot/commands/edit.js
+++ b/bot/commands/edit.js
@@ -1,0 +1,33 @@
+// Edits the message and logs the old content in #bot-log
+const {Command} = require('yuuko');
+
+module.exports = new Command('edit', async (msg, args, context) => {
+	if (args.length < 2) {
+		msg.channel.createMessage(`Command can be used with: \`${context.prefix}say [channelId] [messageId] [text...]\`
+Be sure to use the first line and not leave any whitespace/newline immediately after the channel/message IDs.`).catch(() => {});
+		return;
+	}
+
+	const botLogChannelId = '284412480833191936'; // botlog text channel TODO: Change this to a file
+	const channelId = args[0];
+	const messageId = args[1];
+	const newMessageContent = args.slice(2, args.length).join(' ');
+	const oldMessage = await context.client.getMessage(channelId, messageId).catch(() => {});
+
+	// log the old content just in case
+	context.client.createMessage(botLogChannelId, oldMessage.content).catch(() => {});
+	// same reason as in .say
+	if (newMessageContent.length > 1950) {
+		msg.channel.createMessage('Message is too big!').catch(() => {});
+		return;
+	}
+
+	// edit the message
+	context.client.editMessage(channelId, messageId, newMessageContent).catch(() => {});
+}, {permissions: ['manageMessages']});
+
+// TODO: add args
+module.exports.help = {
+	args: '',
+	desc: 'Edits the message with the given ID, and logs the old content in #bot-log',
+};

--- a/bot/commands/misc/pick.js
+++ b/bot/commands/misc/pick.js
@@ -18,7 +18,7 @@ module.exports = new Command('pick', (msg, args, context) => {
 	choices = choices.map(element => element.trim());
 
 	if (choices.length < 2) {
-		msg.channel.createMessage('Not enough things to pick from!').catch(() => {});
+		msg.channel.createMessage('Not enough things to pick from! Use a comma to separate choices.').catch(() => {});
 	} else {
 		msg.channel.createMessage(`I pick **${choices[getRandomInt(0, choices.length - 1)]}**`).catch(() => {});
 	}

--- a/bot/commands/say.js
+++ b/bot/commands/say.js
@@ -3,32 +3,50 @@
 const {Command} = require('yuuko');
 
 module.exports = new Command('say', async (msg, args, context) => {
+	if (args.length < 1) {
+		msg.channel.createMessage(`Command can be used with: \`${context.prefix}say [channelId] [text...]\`
+Be sure to use the first line and not leave any whitespace/newline immediately after the channel/message IDs.`).catch(() => {});
+		return;
+	}
+
 	// try to get the channel, if none is found just post it in the channel the message was sent
-	// let channel;
-	// throws an error if no argument is supplied, has to be caught
-	// try {
-	// channel = context.client.getChannel(args[0]);
-	// } catch (err) {
-	// channel = undefined;
-	// }
-	const channel = await context.client.getChannel(args[0]).catch(() => console.log('test'));
-	console.log('test2');
+	let channel;
+	try {
+		channel = context.client.getChannel(args[0].split('\n')[0]) || await context.client.getRESTChannel(args[0]);
+	} catch (_) {
+	// pass, channel stays undefined
+	}
+
 
 	if (channel) {
 		const messageContent = args.slice(1, args.length).join(' ');
+		// because .edit requires an extra argument, I'm giving us some breathing room here to not cause a deadlock
+		// where a high char count message would not be editable (the user would not be able to send the command message)
+		// even if keeping the same char count.
+		// Can probably optimize this further to be the exact char count the edit command would take up but different channel IDs
+		// can vary in size iirc (in my tests the total length for .edit was 43 on my server)
+		if (messageContent.length > 1950) {
+			msg.channel.createMessage('Message is too big!').catch(() => {});
+			return;
+		}
+
 		context.client.createMessage(channel.id, messageContent).catch(() => {});
-	} else if (args.length > 0) {
+	} else {
 		const messageContent = args.slice(0, args.length).join(' ');
+		// same as above
+		if (messageContent.length > 1950) {
+			msg.channel.createMessage('Message is too big!').catch(() => {});
+			return;
+		}
+
 		context.client.createMessage(msg.channel.id, messageContent).catch(() => {});
 		// delete the message from the person that used the say command, if it was sent without a channel argument
-		context.client.deleteMessage(msg.channel.id, msg.id, 'Say Command');
-	} else {
-		msg.channel.createMessage(`Command can be used with: \`${context.prefix}say [channelId] [text...]\``).catch(() => {});
+		context.client.deleteMessage(msg.channel.id, msg.id, 'Say Command').catch(() => {});
 	}
 }, {permissions: ['manageMessages']});
 
 // TODO: add args
 module.exports.help = {
 	args: '',
-	desc: 'Says the contents in the specified channel, or in the same channel if no channel is passed',
+	desc: 'Says the contents passed after the specified channel, or in the same channel if no channel is passed.',
 };

--- a/bot/commands/say.js
+++ b/bot/commands/say.js
@@ -1,0 +1,34 @@
+// Says the contents in the specified channel, or in the same channel if no channel is passed
+
+const {Command} = require('yuuko');
+
+module.exports = new Command('say', async (msg, args, context) => {
+	// try to get the channel, if none is found just post it in the channel the message was sent
+	// let channel;
+	// throws an error if no argument is supplied, has to be caught
+	// try {
+	// channel = context.client.getChannel(args[0]);
+	// } catch (err) {
+	// channel = undefined;
+	// }
+	const channel = await context.client.getChannel(args[0]).catch(() => console.log('test'));
+	console.log('test2');
+
+	if (channel) {
+		const messageContent = args.slice(1, args.length).join(' ');
+		context.client.createMessage(channel.id, messageContent).catch(() => {});
+	} else if (args.length > 0) {
+		const messageContent = args.slice(0, args.length).join(' ');
+		context.client.createMessage(msg.channel.id, messageContent).catch(() => {});
+		// delete the message from the person that used the say command, if it was sent without a channel argument
+		context.client.deleteMessage(msg.channel.id, msg.id, 'Say Command');
+	} else {
+		msg.channel.createMessage(`Command can be used with: \`${context.prefix}say [channelId] [text...]\``).catch(() => {});
+	}
+}, {permissions: ['manageMessages']});
+
+// TODO: add args
+module.exports.help = {
+	args: '',
+	desc: 'Says the contents in the specified channel, or in the same channel if no channel is passed',
+};


### PR DESCRIPTION
The whole newline behavior is kinda wonky but I don't think it can be fixed within a command without over complicating things to extremes.

As it stands, I think it works just fine in normal use cases, provided you use the first line and don't skip right ahead. Visually it will look the same and providing support for people to start the block of text  on another line _after_ the arguments seems a bit overkill for a small bit of extra clarity when writing it. 