### PR TITLE
Accept uncached members in parseGuildMember

### DIFF
--- a/bot/commands/moderation/kick.js
+++ b/bot/commands/moderation/kick.js
@@ -17,7 +17,7 @@ function kickMessage (guild, reason) {
 }
 
 module.exports = new Command('kick', async (message, args, {db}) => {
-	const [member, reason] = parseGuildMember(args.join(' '), message.channel.guild);
+	const [member, reason] = await parseGuildMember(args.join(' '), message.channel.guild);
 	if (!member) {
 		message.channel.createMessage('Not sure who you want me to kick. Start your message with a mention, exact tag, or user ID.').catch(() => {});
 		return;

--- a/bot/commands/moderation/warn.js
+++ b/bot/commands/moderation/warn.js
@@ -16,7 +16,7 @@ function warnMessage (guild, reason) {
 }
 
 module.exports = new Command('warn', async (message, args, {db}) => {
-	const [member, reason] = parseGuildMember(args.join(' '), message.channel.guild);
+	const [member, reason] = await parseGuildMember(args.join(' '), message.channel.guild);
 	if (!member) {
 		message.channel.createMessage('Not sure who you want me to warn. Start your message with a mention, exact tag, or user ID.').catch(() => {});
 		return;

--- a/bot/commands/unverify.js
+++ b/bot/commands/unverify.js
@@ -32,7 +32,7 @@ module.exports = new Command(['unverify', 'deverify'], async (msg, args, {db}) =
 
 	// Do we have a Discord tag at the beginning of the message?
 	if (!discordUserID) {
-		const [member, rest] = parseGuildMember(args, msg.channel.guild);
+		const [member, rest] = await parseGuildMember(args, msg.channel.guild);
 		if (member) {
 			discordUserID = member.id;
 			args = rest.trim();

--- a/bot/commands/verify.js
+++ b/bot/commands/verify.js
@@ -34,7 +34,7 @@ module.exports = new Command('verify', async (msg, args, {db, client}) => {
 
 	// Do we have a Discord tag at the beginning of the message?
 	if (!discordUserID) {
-		const [member, rest] = parseGuildMember(args, msg.channel.guild);
+		const [member, rest] = await parseGuildMember(args, msg.channel.guild);
 		if (member) {
 			discordUserID = member.id;
 			args = rest.trim();

--- a/bot/util/discord.js
+++ b/bot/util/discord.js
@@ -53,7 +53,7 @@ module.exports = {
 
 		// Members of the given guild, if any
 		if (guild) {
-			const [member, rest] = module.exports.parseGuildMember(str, guild, me);
+			const [member, rest] = await module.exports.parseGuildMember(str, guild, me);
 			if (member) return [member.user, rest];
 		}
 
@@ -79,7 +79,7 @@ module.exports = {
 	 * @returns {Array} An array where the first item is either a Member or
 	 * undefined, and the second item is the rest of the string
 	 */
-	parseGuildMember (str, guild, me) {
+	async parseGuildMember (str, guild, me) {
 		let match;
 
 		// The "me" keyword, if we're provided with a context for it
@@ -91,7 +91,7 @@ module.exports = {
 		// Actual user mentions and raw IDs
 		match = str.match(/^(?:<@!?)?(\d+)>?(?:\s+|$)/);
 		if (match) {
-			const member = guild.members.get(match[1]);
+			const member = guild.members.get(match[1]) || await guild.getRESTMember(match[1]);
 			if (member) return [member, str.substr(match[0].length)];
 		}
 


### PR DESCRIPTION
Fixes an issue where a member wouldn't be accepted by commands even in ID/mention form.