### PR TITLE
Better convert

### DIFF
--- a/bot/commands/misc/convert.js
+++ b/bot/commands/misc/convert.js
@@ -4,51 +4,88 @@ const {Command} = require('yuuko');
 const fetch = require('node-fetch');
 const convert = require('convert-units');
 
+/**
+ * Attempts to convert between common units.
+ * @param {number} baseValue
+ * @param {string} baseType Base unit
+ * @param {string} targetType Target unit
+ * @returns {strung} Success message
+ * @throws {Error} Generic error if conversion fails
+ */
 function convertUnits (baseValue, baseType, targetType) {
 	const conversion = convert(baseValue).from(baseType).to(targetType);
 	return `${baseValue}${baseType} is equal to ${conversion.toFixed(2)}${targetType}`;
 }
 
-async function convertCurrency (baseValue, baseType, targetType, prefix) {
+/**
+ * Attempts to convert between currencies using an exchange rate API.
+ * @param {number} baseValue
+ * @param {string} baseType Base unit
+ * @param {string} targetType Target unit
+ * @returns {Promise<string, Error>} Message to the user if successful, rejects generic error if unsuccessful
+ */
+async function convertCurrency (baseValue, baseType, targetType) {
 	baseType = baseType.toUpperCase();
 	targetType = targetType.toUpperCase();
-	try {
-		const res = await fetch(`https://api.exchangeratesapi.io/latest?base=${baseType}&symbols=${targetType}`);
-		if (res.status !== 200) {
-			throw new Error(`Error fetching from API or you introduced the wrong units. Type \`${prefix}convert\` to see every unit code.`);
-		}
-		const conversions = await res.json();
-		const result = conversions.rates[targetType] * baseValue;
-		return `${baseValue}${baseType} is roughly equal to ${result.toFixed(2)}${targetType}`;
-	} catch (err) {
-		return err.message;
+	const res = await fetch(`https://api.exchangeratesapi.io/latest?base=${baseType}&symbols=${targetType}`);
+	if (res.status !== 200) {
+		throw new Error('non-OK status code');
 	}
+	const conversions = await res.json();
+	const result = conversions.rates[targetType] * baseValue;
+	return `${baseValue}${baseType} is roughly equal to ${result.toFixed(2)}${targetType}`;
 }
 
+/** Regular expression matching input arguments for this command. */
+const argRegex = /^(?<num>\d+([.,]\d+)?)?\s*(?<baseType>[^\s\d]+)(\s*to)?\s*(?<targetType>\S+)$/;
+
+/** Map of unit aliases. */
+const unitAliases = {
+	'"': 'ft',
+	'\'': 'in',
+	'foot': 'ft',
+	'feet': 'ft',
+	'inch': 'in',
+	'inches': 'in',
+};
+
 module.exports = new Command('convert', async (msg, args, context) => {
-	if (args.length < 3) {
+	const match = args.join(' ').match(argRegex);
+
+	if (!match) {
 		msg.channel.createMessage(`For currency codes visit: <https://www.xe.com/en/iso4217.php>
-For units visit: <https://www.npmjs.com/package/convert-units>
+For units visit: <https://www.npmjs.com/package/convert-units#supported-units>
 Command can be used with: \`${context.prefix}convert [amount] [baseUnit] [targetUnit]\``).catch(() => {});
 		return;
 	}
-	const baseValue = parseFloat(args[0].replace(/,/g, '.')); // replace commas with dots since some people use those for decimals
 
-	if (isNaN(baseValue)) {
-		msg.channel.createMessage('Please enter a valid number!');
-		return;
+	let {baseType, targetType} = match.groups;
+	baseType = baseType.toLowerCase();
+	targetType = targetType.toLowerCase();
+
+	for (const [key, value] of Object.entries(unitAliases)) {
+		if (baseType === key) baseType = value;
+		if (targetType === key) targetType = value;
 	}
-	const baseType = args[1];
-	const targetType = args[2];
-	const prefix = context.prefix;
+
+	const baseValue = match.groups.num || 1;
+
+	let message;
 	try {
 		// see if it can convert it normally first
-		msg.channel.createMessage(convertUnits(baseValue, baseType, targetType)).catch(() => {});
-	} catch (err) {
-		// if it can't convert it normally, try to find it as a currency, throws if it can't find a currency either
-		msg.channel.createMessage(await convertCurrency(baseValue, baseType, targetType, prefix)).catch(() => {});
+		message = convertUnits(baseValue, baseType, targetType);
+	} catch (_) {
+		try {
+			// if it can't convert it normally, try to find it as a currency, throws if it can't find a currency either
+			message = await convertCurrency(baseValue, baseType, targetType);
+		} catch (__) {
+			message = `Couldn't convert from ${baseValue} ${baseType} to ${baseValue}. Type \`${context.prefix}convert\` to see all available units.`;
+		}
 	}
+
+	msg.channel.createMessage(message).catch(() => {});
 });
+
 // TODO: add args
 module.exports.help = {
 	args: '',

--- a/bot/commands/misc/convert.js
+++ b/bot/commands/misc/convert.js
@@ -68,7 +68,10 @@ Command can be used with: \`${context.prefix}convert [amount] [baseUnit] [target
 		if (targetType === key) targetType = value;
 	}
 
-	const baseValue = match.groups.num || 1;
+	let baseValue = parseFloat(match.groups.num.replace(',', '.'));
+	if (isNaN(baseValue)) {
+		baseValue = 1;
+	}
 
 	let message;
 	try {


### PR DESCRIPTION
Adds support for unit aliases, a defauly conversion value of 1, somewhat lenient whitespace, and "to" between units in arguments. Fixes #78. The following forms are now valid:

- `.convert usd jpy`
- `.convert 1ft "`
- `.convert 2 feet to inches`

The following aliases are supported:

- `'` to `ft`
- `foot` to `ft`
- `feet` to `ft`
- `"` to `in`
- `inch` to `in`
- `inches` to `in`

Should add more aliases than this but it's 4am, new issue for that.

The general form is now something like `[number?] [unit 1] [to?] [unit 2]` where only the two units are required and a space is not requred between the number and the first unit.