### PR TITLE
Help info from commands

### DIFF
--- a/bot/commands/debug.js
+++ b/bot/commands/debug.js
@@ -3,6 +3,5 @@
 module.exports = require('yuuko/dist/commands/debug');
 
 module.exports.help = {
-	args: '',
 	desc: 'Allows the bot owner to execute aribrary JavaScript expressions in the same scope as the bot',
 };

--- a/bot/commands/edit.js
+++ b/bot/commands/edit.js
@@ -25,7 +25,6 @@ module.exports = new Command('edit', async (msg, args, context) => {
 	context.client.editMessage(channelId, messageId, newMessageContent).catch(() => {});
 }, {permissions: ['manageMessages']});
 
-// TODO: add args
 module.exports.help = {
 	args: '<channel ID> <message ID> <message text...>',
 	desc: `Edits the given message to have the given content. Logs the previous content in <#${botLogChannelId}>.`,

--- a/bot/commands/edit.js
+++ b/bot/commands/edit.js
@@ -1,18 +1,13 @@
 // Edits the message and logs the old content in #bot-log
 const {Command} = require('yuuko');
 
+const botLogChannelId = '284412480833191936'; // botlog text channel TODO: Change this to a file
+
 module.exports = new Command('edit', async (msg, args, context) => {
-	if (!args.length) {
+	if (args.length < 2) {
 		return context.sendHelp(msg, context);
 	}
 
-	if (args.length < 2) {
-		msg.channel.createMessage(`Command can be used with: \`${context.prefix}edit [channelId] [messageId] [text...]\`
-Be sure to use the first line and not leave any whitespace/newline immediately after the channel/message IDs.`).catch(() => {});
-		return;
-	}
-
-	const botLogChannelId = '284412480833191936'; // botlog text channel TODO: Change this to a file
 	const channelId = args[0];
 	const messageId = args[1];
 	const newMessageContent = args.slice(2, args.length).join(' ');
@@ -32,6 +27,6 @@ Be sure to use the first line and not leave any whitespace/newline immediately a
 
 // TODO: add args
 module.exports.help = {
-	args: '',
-	desc: 'Edits the message with the given ID, and logs the old content in #bot-log',
+	args: '<channel ID> <message ID> <message text...>',
+	desc: `Edits the given message to have the given content. Logs the previous content in <#${botLogChannelId}>.`,
 };

--- a/bot/commands/edit.js
+++ b/bot/commands/edit.js
@@ -2,6 +2,10 @@
 const {Command} = require('yuuko');
 
 module.exports = new Command('edit', async (msg, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(msg, context);
+	}
+
 	if (args.length < 2) {
 		msg.channel.createMessage(`Command can be used with: \`${context.prefix}edit [channelId] [messageId] [text...]\`
 Be sure to use the first line and not leave any whitespace/newline immediately after the channel/message IDs.`).catch(() => {});

--- a/bot/commands/misc/avatar.js
+++ b/bot/commands/misc/avatar.js
@@ -16,7 +16,6 @@ module.exports = new Command('avatar', async (msg, args) => {
 	msg.channel.createMessage(member.avatarURL).catch(() => {});
 });
 
-// TODO: add args
 module.exports.help = {
 	args: '[user]',
 	desc: 'Shows your avatar, or the avatar of the given user.',

--- a/bot/commands/misc/avatar.js
+++ b/bot/commands/misc/avatar.js
@@ -18,6 +18,6 @@ module.exports = new Command('avatar', async (msg, args) => {
 
 // TODO: add args
 module.exports.help = {
-	args: '<user>',
-	desc: 'Shows the avatar of the user provided.',
+	args: '[user]',
+	desc: 'Shows your avatar, or the avatar of the given user.',
 };

--- a/bot/commands/misc/convert.js
+++ b/bot/commands/misc/convert.js
@@ -53,10 +53,7 @@ module.exports = new Command('convert', async (msg, args, context) => {
 	const match = args.join(' ').match(argRegex);
 
 	if (!match) {
-		msg.channel.createMessage(`For currency codes visit: <https://www.xe.com/en/iso4217.php>
-For units visit: <https://www.npmjs.com/package/convert-units#supported-units>
-Command can be used with: \`${context.prefix}convert [amount] [baseUnit] [targetUnit]\``).catch(() => {});
-		return;
+		return context.sendHelp(msg, context);
 	}
 
 	let {baseType, targetType} = match.groups;
@@ -92,5 +89,7 @@ Command can be used with: \`${context.prefix}convert [amount] [baseUnit] [target
 // TODO: add args
 module.exports.help = {
 	args: '<amount> <source currency or unit> <destination currency or unit>',
-	desc: 'Converts units and currency, the latter being based on this API: <http://exchangeratesapi.io/>',
+	desc: `Converts units and currency. Uses <http://exchangeratesapi.io/> for live currency exchange rates.
+For a list of valid currency codes, visit: <https://www.xe.com/en/iso4217.php>
+For a list of valid units, visit: <https://www.npmjs.com/package/convert-units#supported-units>`,
 };

--- a/bot/commands/misc/convert.js
+++ b/bot/commands/misc/convert.js
@@ -86,10 +86,9 @@ module.exports = new Command('convert', async (msg, args, context) => {
 	msg.channel.createMessage(message).catch(() => {});
 });
 
-// TODO: add args
 module.exports.help = {
-	args: '<amount> <source currency or unit> <destination currency or unit>',
-	desc: `Converts units and currency. Uses <http://exchangeratesapi.io/> for live currency exchange rates.
+	args: '[amount] <source currency or unit> <destination currency or unit>',
+	desc: `Converts units and currency. Uses <http://exchangeratesapi.io/> for live currency exchange rates. If no amount is specified, assumes 1.
 For a list of valid currency codes, visit: <https://www.xe.com/en/iso4217.php>
 For a list of valid units, visit: <https://www.npmjs.com/package/convert-units#supported-units>`,
 };

--- a/bot/commands/misc/joke.js
+++ b/bot/commands/misc/joke.js
@@ -16,8 +16,6 @@ module.exports = new Command('joke', async msg => {
 		msg.channel.createMessage(err.message).catch(() => {});
 	}
 });
-// TODO: add args
 module.exports.help = {
-	args: '',
 	desc: 'Fetches a random joke from <https://github.com/15Dkatz/official_joke_api>',
 };

--- a/bot/commands/misc/pick.js
+++ b/bot/commands/misc/pick.js
@@ -9,23 +9,18 @@ function getRandomInt (min, max) {
 }
 
 module.exports = new Command('pick', (msg, args, context) => {
-	// We use a comma as a separator for each choice, and we don't use args because want choices to have spaces
-	let choices = msg.content.split(',');
-
-	// Remove the command from the first choice, don't want the bot to say 'I pick .pick firstChoice'
-	choices[0] = choices[0].replace(`${context.prefix}pick`, '');
-
-	choices = choices.map(element => element.trim());
-
-	if (choices.length < 2) {
-		msg.channel.createMessage('Not enough things to pick from! Use a comma to separate choices.').catch(() => {});
-	} else {
-		msg.channel.createMessage(`I pick **${choices[getRandomInt(0, choices.length - 1)]}**`).catch(() => {});
+	if (!args.length) {
+		return context.sendHelp(msg, context);
 	}
+
+	// We use a comma as a separator for each choice
+	const choices = args.join(' ').split(',').map(str => str.trim());
+
+	msg.channel.createMessage(`I pick **${choices[getRandomInt(0, choices.length - 1)]}**`).catch(() => {});
 });
 
 // TODO: add args
 module.exports.help = {
-	args: '<Comma-seperated list of items>',
-	desc: 'Picks from the options provided, separate them with a comma.',
+	args: '<choice>, <choice>, <more choices...>',
+	desc: 'Picks randomly from the given options. Options are separated with commas.',
 };

--- a/bot/commands/misc/pick.js
+++ b/bot/commands/misc/pick.js
@@ -19,7 +19,6 @@ module.exports = new Command('pick', (msg, args, context) => {
 	msg.channel.createMessage(`I pick **${choices[getRandomInt(0, choices.length - 1)]}**`).catch(() => {});
 });
 
-// TODO: add args
 module.exports.help = {
 	args: '<choice>, <choice>, <more choices...>',
 	desc: 'Picks randomly from the given options. Options are separated with commas.',

--- a/bot/commands/misc/roll.js
+++ b/bot/commands/misc/roll.js
@@ -23,8 +23,6 @@ module.exports = new Command('roll', (msg, args) => {
 		msg.channel.createMessage(`You rolled a ${getRandomInt(min, max)}`).catch(() => {});
 	}
 });
-
-// TODO: add args
 module.exports.help = {
 	args: '[lowest number] [highest number]',
 	desc: 'Rolls between 2 numbers provided or a default interval of 0-6',

--- a/bot/commands/moderation/ban.js
+++ b/bot/commands/moderation/ban.js
@@ -16,7 +16,12 @@ function banMessage (guild, reason, expirationDate) {
 	return `You've been banned from __${escape(guild.name)}__ ${expirationDate ? `until ${formatDateTime(expirationDate)}` : 'permanently'}.\n${reason ? blockquote(escape(reason)) : ''}`;
 }
 
-module.exports = new Command('ban', async (message, args, {db}) => {
+module.exports = new Command('ban', async (message, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(message, context);
+	}
+	const {db} = context;
+
 	const [user, rest] = await parseUser(args.join(' '), message.channel.guild);
 	if (!user) {
 		message.channel.createMessage('Not sure who you want me to ban. Start your message with a mention, exact tag, or user ID.').catch(() => {});

--- a/bot/commands/moderation/kick.js
+++ b/bot/commands/moderation/kick.js
@@ -16,7 +16,12 @@ function kickMessage (guild, reason) {
 	return `You've been kicked from __${escape(guild.name)}__.\n${reason ? blockquote(escape(reason)) : ''}`;
 }
 
-module.exports = new Command('kick', async (message, args, {db}) => {
+module.exports = new Command('kick', async (message, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(message, context);
+	}
+	const {db} = context;
+
 	const [member, reason] = await parseGuildMember(args.join(' '), message.channel.guild);
 	if (!member) {
 		message.channel.createMessage('Not sure who you want me to kick. Start your message with a mention, exact tag, or user ID.').catch(() => {});

--- a/bot/commands/moderation/note.js
+++ b/bot/commands/moderation/note.js
@@ -2,7 +2,12 @@ const log = require('another-logger')({label: 'command:note'});
 const {Command} = require('yuuko');
 const {parseUser} = require('../../util/discord');
 
-module.exports = new Command('note', async (message, args, {db}) => {
+module.exports = new Command('note', async (message, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(message, context);
+	}
+	const {db} = context;
+
 	const [member, reason] = await parseUser(args.join(' '), message.channel.guild);
 	if (!member) {
 		message.channel.createMessage('Not sure who you want me to add the note to. Start your message with a mention, exact tag, or user ID.').catch(() => {});

--- a/bot/commands/moderation/unban.js
+++ b/bot/commands/moderation/unban.js
@@ -2,7 +2,12 @@ const log = require('another-logger')({label: 'command:unban'});
 const {Command} = require('yuuko');
 const {parseUser} = require('../../util/discord');
 
-module.exports = new Command('unban', async (message, args, {db}) => {
+module.exports = new Command('unban', async (message, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(message, context);
+	}
+	const {db} = context;
+
 	const [user] = await parseUser(args.join(' ').trim(), message.channel.guild);
 	if (!user) {
 		message.channel.createMessage("Couldn't tell who you mean. Use a user ID or direct mention (user#discrim won't work).").catch(() => {});

--- a/bot/commands/moderation/warn.js
+++ b/bot/commands/moderation/warn.js
@@ -15,7 +15,12 @@ function warnMessage (guild, reason) {
 	return `You've been issued a warning in __${escape(guild.name)}__.\n${reason ? blockquote(escape(reason)) : ''}`;
 }
 
-module.exports = new Command('warn', async (message, args, {db}) => {
+module.exports = new Command('warn', async (message, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(message, context);
+	}
+	const {db} = context;
+
 	const [member, reason] = await parseGuildMember(args.join(' '), message.channel.guild);
 	if (!member) {
 		message.channel.createMessage('Not sure who you want me to warn. Start your message with a mention, exact tag, or user ID.').catch(() => {});

--- a/bot/commands/ping.js
+++ b/bot/commands/ping.js
@@ -8,6 +8,5 @@ module.exports = new Command('ping', async msg => {
 	newMsg.edit(`${newMsg.content} (${Date.now() - then}ms)`);
 });
 module.exports.help = {
-	args: '',
 	desc: 'Pings the bot and shows how long it takes to send a response.',
 };

--- a/bot/commands/reload.js
+++ b/bot/commands/reload.js
@@ -3,6 +3,5 @@
 module.exports = require('yuuko/dist/commands/reload');
 
 module.exports.help = {
-	args: '',
 	desc: 'Allows the bot owner to reload the bot from disk for development purposes.',
 };

--- a/bot/commands/reminders/remind.js
+++ b/bot/commands/reminders/remind.js
@@ -4,7 +4,12 @@
 const {Command} = require('yuuko');
 const log = require('another-logger');
 
-module.exports = new Command('remind', async (message, args, {db}) => {
+module.exports = new Command('remind', async (message, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(message, context);
+	}
+	const {db} = context;
+
 	// TODO: actually parse a date from arguments
 	const due = new Date(Date.now() + 1000 * 60); // one minute from now
 	// Reminder's text is just the entire rest of the message

--- a/bot/commands/say.js
+++ b/bot/commands/say.js
@@ -3,10 +3,8 @@
 const {Command} = require('yuuko');
 
 module.exports = new Command('say', async (msg, args, context) => {
-	if (args.length < 1) {
-		msg.channel.createMessage(`Command can be used with: \`${context.prefix}say [channelId] [text...]\`
-Be sure to use the first line and not leave any whitespace/newline immediately after the channel/message IDs.`).catch(() => {});
-		return;
+	if (!args.length) {
+		return context.sendHelp(msg, context);
 	}
 
 	// try to get the channel, if none is found just post it in the channel the message was sent

--- a/bot/commands/say.js
+++ b/bot/commands/say.js
@@ -42,7 +42,6 @@ module.exports = new Command('say', async (msg, args, context) => {
 	}
 }, {permissions: ['manageMessages']});
 
-// TODO: add args
 module.exports.help = {
 	args: '<channel> <message>',
 	desc: 'Says the contents passed after the specified channel, or in the same channel if no channel is passed.',

--- a/bot/commands/say.js
+++ b/bot/commands/say.js
@@ -12,9 +12,8 @@ module.exports = new Command('say', async (msg, args, context) => {
 	try {
 		channel = context.client.getChannel(args[0].split('\n')[0]) || await context.client.getRESTChannel(args[0]);
 	} catch (_) {
-	// pass, channel stays undefined
+		// pass, channel stays undefined
 	}
-
 
 	if (channel) {
 		const messageContent = args.slice(1, args.length).join(' ');

--- a/bot/commands/unverify.js
+++ b/bot/commands/unverify.js
@@ -6,7 +6,12 @@ const config = require('../../config');
 
 const confirmationEmoji = '💔';
 
-module.exports = new Command(['unverify', 'deverify'], async (msg, args, {db}) => {
+module.exports = new Command(['unverify', 'deverify'], async (msg, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(msg, context);
+	}
+	const {db} = context;
+
 	args = args.join(' ').trim();
 
 	// This command takes two arguments, a Reddit username and a Discord user;

--- a/bot/commands/unverify.js
+++ b/bot/commands/unverify.js
@@ -155,5 +155,5 @@ module.exports = new Command(['unverify', 'deverify'], async (msg, args, context
 
 module.exports.help = {
 	args: '<discord user> <reddit username>',
-	desc: 'Deletes the connection between the indicated Discord user name and the indicated Reddit user name. \n If only one is provided, deletes all associations with the indicated name.',
+	desc: 'Deletes the connection between the indicated Discord user name and the indicated Reddit user name. If only one is provided, deletes all associations with the indicated name.',
 };

--- a/bot/commands/verify.js
+++ b/bot/commands/verify.js
@@ -5,7 +5,12 @@ const {escape} = require('../util/formatting');
 
 const confirmationEmoji = '✅';
 
-module.exports = new Command('verify', async (msg, args, {db, client}) => {
+module.exports = new Command('verify', async (msg, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(msg, context);
+	}
+	const {db, client} = context;
+
 	args = args.join(' ').trim();
 
 	// This command takes two arguments, a reddit user and a Discord user. Each

--- a/bot/commands/whois.js
+++ b/bot/commands/whois.js
@@ -69,7 +69,12 @@ async function notesLine (userID, guildID, db) {
 	}`;
 }
 
-module.exports = new Command('whois', async (message, args, {db}) => {
+module.exports = new Command('whois', async (message, args, context) => {
+	if (!args.length) {
+		return context.sendHelp(message, context);
+	}
+	const {db} = context;
+
 	const [user] = await parseUser(args.join(' '), message.channel.guild, message.author);
 	if (!user) {
 		const match = args.join(' ').match(/(?:\/?u\/)?([a-zA-Z0-9-_]+)/);

--- a/bot/index.js
+++ b/bot/index.js
@@ -35,6 +35,17 @@ module.exports = (mongoClient, db) => {
 	bot.addDir(path.join(__dirname, 'commands'));
 	bot.addDir(path.join(__dirname, 'events'));
 
+	// Make a helper for displaying help information from commands
+	const helpCommand = bot.commandForName('help');
+	bot.extendContext({
+		helpCommand,
+		sendHelp (msg, ctx) {
+			const command = ctx.commandName;
+			ctx.commandName = helpCommand.names[0];
+			helpCommand.process(msg, command.split(' '), ctx);
+		},
+	});
+
 	// Connect the bot to Discord
 	bot.connect();
 


### PR DESCRIPTION
Added a helper function for triggering the help command from another command. Used this instead of ad-hoc help message sending to present a unified interface for command information.

This only applies to commands which have some sort of error condition when their arguments aren't fulfilled; commands like ping and joke don't take arguments, so nothing changed there.

Fixes #84.