### PR TITLE
Filter functions in commands

### DIFF
--- a/bot/commands/moderation/filteradd.js
+++ b/bot/commands/moderation/filteradd.js
@@ -1,0 +1,80 @@
+const {Command} = require('yuuko');
+const log = require('another-logger');
+const {isValidRule} = require('../../../common/filters');
+const {escape} = require('../../util/formatting');
+
+function makeRuleForText (text) {
+	const rule = {
+		type: 'containsText',
+		field: 'content',
+		text,
+	};
+
+	// Temporary runtime check to ensure the created rule is valid
+	// TODO: remove this check once confident it won't blow up
+	if (!isValidRule(rule)) {
+		throw new TypeError('Computed rule was invalid');
+	}
+
+	return rule;
+}
+
+module.exports = new Command('filteradd', async (msg, args, {db}) => {
+	const guildID = msg.channel.guild.id;
+	const ruleText = args.join(' ');
+
+	// Fetch the existing configuration
+	const filterConfig = await db.collection('messageFilters').findOne({guildID});
+	const existingRule = filterConfig ? filterConfig.rule : null;
+
+	// Modify the existing rule to add the new phrase
+	let rule = makeRuleForText(ruleText);
+	if (existingRule.type === 'multiple' && existingRule.op === 'or') {
+		// If we already have a top-level "or" rule, we add the new rule as a child of that one
+		existingRule.children.push(rule);
+		rule = existingRule;
+	} else {
+		// Otherwise, wrap the rule in a new "or" rule and use that
+		rule = {
+			type: 'multiple',
+			op: 'or',
+			children: [
+				rule,
+			],
+		};
+		// existingRule might be null if the guild didn't have any rule yet, in which case we don't care about it, but
+		// if there *is* a rule already there, then it needs to be included in the children of the new top-level rule
+		if (existingRule) {
+			rule.children.unshift(existingRule);
+		}
+	}
+
+	// Another temporary runtime check to ensure the created rule is valid
+	// TODO: remove this check once confident it won't blow up
+	if (!isValidRule(rule)) {
+		throw new TypeError('Computed rule was invalid');
+	}
+
+	// Write the rule to the database
+	try {
+		await db.collection('messageFilters').replaceOne({guildID}, {guildID, rule}, {
+			upsert: true,
+		});
+	} catch (error) {
+		log.error(`Database error while writing filter config for guild ${guildID}:`, error);
+		msg.channel.createMessage('Failed to write the new filter. Try adding via the website instead.').catch(() => {});
+		return;
+	}
+
+	msg.channel.createMessage(`Created new filter for \`${escape(ruleText)}\`.`).catch(() => {});
+}, {
+	guildOnly: true,
+	permissions: [
+		'manageMessages',
+	],
+});
+
+module.exports.help = {
+	args: '<filter text>',
+	desc: 'Adds a new filter rule which matches the given text.',
+};

--- a/bot/commands/moderation/filteradd.js
+++ b/bot/commands/moderation/filteradd.js
@@ -21,7 +21,7 @@ function makeRuleForText (text) {
 
 module.exports = new Command('filteradd', async (msg, args, {db}) => {
 	const guildID = msg.channel.guild.id;
-	const ruleText = args.join(' ');
+	const ruleText = args.join(' ').toLowerCase();
 
 	// Fetch the existing configuration
 	const filterConfig = await db.collection('messageFilters').findOne({guildID});

--- a/bot/commands/moderation/filteradd.js
+++ b/bot/commands/moderation/filteradd.js
@@ -20,6 +20,11 @@ function makeRuleForText (text) {
 }
 
 module.exports = new Command('filteradd', async (msg, args, {db}) => {
+	if (!args.length) {
+		msg.channel.createMessage('Don\'t know what filter you want to add.').catch(() => {});
+		return;
+	}
+
 	const guildID = msg.channel.guild.id;
 	const ruleText = args.join(' ').toLowerCase();
 

--- a/bot/commands/moderation/filterdel.js
+++ b/bot/commands/moderation/filterdel.js
@@ -1,0 +1,49 @@
+const {Command} = require('yuuko');
+const log = require('another-logger');
+const {escape} = require('../../util/formatting');
+
+module.exports = new Command(['filterdel', 'filterdelete', 'filterremove'], async (msg, args, {db}) => {
+	const guildID = msg.channel.guild.id;
+	const ruleText = args.join(' ').toLowerCase();
+
+	// Fetch the existing configuration
+	const filterConfig = await db.collection('messageFilters').findOne({guildID});
+
+	// Only search for the rule as a direct child of a top-level "or" rule - ignore if there is no config yet
+	if (filterConfig && filterConfig.rule.type === 'multiple' && filterConfig.rule.op === 'or') {
+		const rule = filterConfig.rule;
+
+		// Find the rule as a direct child of the top-level rule
+		const index = rule.children.findIndex(childRule => childRule.type === 'containsText' && childRule.field === 'content' && childRule.text.toLowerCase() === ruleText);
+		if (index !== -1) {
+			// Remove the child rule
+			filterConfig.rule.children.splice(index, 1);
+
+			// Write the rule to the database
+			try {
+				await db.collection('messageFilters').replaceOne({guildID}, {guildID, rule}, {
+					upsert: true,
+				});
+			} catch (error) {
+				log.error(`Database error while writing filter config for guild ${guildID}:`, error);
+				msg.channel.createMessage('Failed to write the new filter. Try adding via the website instead.').catch(() => {});
+				return;
+			}
+
+			msg.channel.createMessage(`Deleted the filter for \`${escape(ruleText)}\`.`).catch(() => {});
+			return;
+		}
+	}
+
+	msg.channel.createMessage(`No filter found for \`${escape(ruleText)}\`. (This command is naive; consider checking the website.)`).catch(() => {});
+}, {
+	guildOnly: true,
+	permissions: [
+		'manageMessages',
+	],
+});
+
+module.exports.help = {
+	args: '<filter text>',
+	desc: 'Removes an existing filter rule which matches the given text.',
+};

--- a/bot/commands/moderation/filterdel.js
+++ b/bot/commands/moderation/filterdel.js
@@ -3,6 +3,11 @@ const log = require('another-logger');
 const {escape} = require('../../util/formatting');
 
 module.exports = new Command(['filterdel', 'filterdelete', 'filterremove'], async (msg, args, {db}) => {
+	if (!args.length) {
+		msg.channel.createMessage('Don\'t know what filter you want to delete.').catch(() => {});
+		return;
+	}
+
 	const guildID = msg.channel.guild.id;
 	const ruleText = args.join(' ').toLowerCase();
 

--- a/bot/events/messageCreate.js
+++ b/bot/events/messageCreate.js
@@ -9,17 +9,14 @@ module.exports = new EventListener('messageCreate', async (message, {client, db}
 		const configuration = await db.collection('messageFilters').findOne({guildID: message.guildID});
 		if (configuration && configuration.rule) {
 			const {rule} = configuration;
-
-			// Map each filter to a promise returning whether or not the message matches that filter
-			if (!isValidRule(rule)) {
-				log.error('Invalid rulE???', rule);
-				return false;
-			}
-
-			// As soon as any of those promises resolves to true, we know the message is invalid, so we delete it
-			if (await messageMatchesRule(message, rule)) {
-				message.delete().catch(() => {});
-				return;
+			if (isValidRule(rule)) {
+				if (await messageMatchesRule(message, rule)) {
+					message.delete().catch(() => {});
+					return;
+				}
+			} else {
+				// weird
+				log.error('Encountered invalid rule in guild', message.guildID, rule);
 			}
 		}
 	}

--- a/bot/events/messageCreate.js
+++ b/bot/events/messageCreate.js
@@ -7,16 +7,20 @@ module.exports = new EventListener('messageCreate', async (message, {client, db}
 	if (message.guildID) {
 		// Fetch filter for this guild
 		const configuration = await db.collection('messageFilters').findOne({guildID: message.guildID});
-		if (configuration && configuration.rule) {
-			const {rule} = configuration;
-			if (isValidRule(rule)) {
-				if (await messageMatchesRule(message, rule)) {
-					message.delete().catch(() => {});
-					return;
+
+		// TODO: temporary hardcode to ignore the filter for people with manage messages
+		if (!message.channel.permissionsOf(message.author.id).has('manageMessages')) {
+			if (configuration && configuration.rule) {
+				const {rule} = configuration;
+				if (isValidRule(rule)) {
+					if (await messageMatchesRule(message, rule)) {
+						message.delete().catch(() => {});
+						return;
+					}
+				} else {
+					// weird
+					log.error('Encountered invalid rule in guild', message.guildID, rule);
 				}
-			} else {
-				// weird
-				log.error('Encountered invalid rule in guild', message.guildID, rule);
 			}
 		}
 	}


### PR DESCRIPTION
Adds `.filteradd` and `.filterdel` which can be used to modify the filter rule from chat. They create/remove simple text match rules for message content.

Partially addresses #98. These will still need to be moved to subcommands of `.filter` when Yuuko supports subcommands.