### PR TITLE
Support deleting notes, warnings, kicks from website

### DIFF
--- a/web/frontend/views/guild/MemberInfo.vue
+++ b/web/frontend/views/guild/MemberInfo.vue
@@ -26,7 +26,10 @@
 					<td>{{ thing.note }}</td>
 					<td>{{ thing.modID }}</td>
 					<td>
-						<b-dropdown position="is-bottom-left">
+						<b-dropdown
+							v-if="thing.type !== 'ban'"
+							position="is-bottom-left"
+						>
 							<template #trigger>
 								<b-button
 									label="Actions..."

--- a/web/frontend/views/guild/MemberInfo.vue
+++ b/web/frontend/views/guild/MemberInfo.vue
@@ -114,7 +114,7 @@ export default {
 						duration: 1000,
 						message: `Deleted ${thing.type}.`,
 						position: 'is-bottom',
-						type: 'is-danger',
+						type: 'is-success',
 					});
 					// remove item from display
 					// TODO: oh my lord please no this is terrible #94

--- a/web/frontend/views/guild/MemberInfo.vue
+++ b/web/frontend/views/guild/MemberInfo.vue
@@ -13,6 +13,7 @@
 					<th>Type</th>
 					<th>Note</th>
 					<th>Moderator</th>
+					<th />
 				</tr>
 			</thead>
 			<tbody>
@@ -24,6 +25,22 @@
 					<td>{{ thing.type }}</td>
 					<td>{{ thing.note }}</td>
 					<td>{{ thing.modID }}</td>
+					<td>
+						<b-dropdown position="is-bottom-left">
+							<template #trigger>
+								<b-button
+									label="Actions..."
+									size="is-small"
+								/>
+							</template>
+							<b-dropdown-item
+								class="has-text-danger"
+								@click="deleteThing(thing)"
+							>
+								Delete
+							</b-dropdown-item>
+						</b-dropdown>
+					</td>
 				</tr>
 			</tbody>
 		</table>
@@ -86,6 +103,40 @@ export default {
 			this.kicks = kicks;
 			this.bans = bans;
 		});
+	},
+	methods: {
+		deleteThing (thing) {
+			fetch(`/api/guilds/${this.guildID}/members/${this.userID}/${thing.type}s/${thing._id}`, {
+				method: 'DELETE',
+			}).then(response => {
+				if (response.ok) {
+					this.$buefy.toast.open({
+						duration: 1000,
+						message: `Deleted ${thing.type}.`,
+						position: 'is-bottom',
+						type: 'is-danger',
+					});
+					// remove item from display
+					// TODO: oh my lord please no this is terrible #94
+					const things = this[`${thing.type}s`];
+					things.splice(things.findIndex(t => t._id === thing._id), 1);
+				} else {
+					console.error(`Non-OK response with code ${response.status} when deleting ${thing.type} ${thing._id}:`, response);
+					this.$buefy.toast.open({
+						duration: 3000,
+						message: `Failed to delete ${thing.type}.`,
+						position: 'is-bottom',
+						type: 'is-danger',
+					});
+				}
+			}, error => {
+				console.error(`Network error when deleting ${thing.type} ${thing._id}:`, error);
+				this.$buefy.toast.open({
+					duration: 3000,
+					message: 'Network error, please try again. More information in console.',
+				});
+			});
+		},
 	},
 };
 </script>


### PR DESCRIPTION
Bans are intentionally excluded from this PR because "deleting" a ban requires replicating the logic of the `.unban` command, and I want to unify that more properly. I don't want to do anything too complicated here before #94 - I have an idea for a better method of "deleting" things to maintain a more accurate user history in the case of mod error, but it's not practical until that gets done.

Fixes #103 for now. Will make a separate issue for adding unban functionality to the site.