### PR TITLE
Fixed the convert command

### DIFF
--- a/bot/commands/misc/convert.js
+++ b/bot/commands/misc/convert.js
@@ -79,7 +79,7 @@ module.exports = new Command('convert', async (msg, args, context) => {
 		try {
 			// if it can't convert it normally, try to find it as a currency, throws if it can't find a currency either
 			message = await convertCurrency(baseValue, baseType, targetType);
-		} catch (error) {
+		} catch (__) {
 			message = `Couldn't convert from ${baseValue} ${baseType} to ${targetType}. Type \`${context.prefix}convert\` to see all available units.`;
 		}
 	}

--- a/bot/commands/misc/convert.js
+++ b/bot/commands/misc/convert.js
@@ -1,6 +1,7 @@
 // Converts from one currency to another based on this API: http://exchangeratesapi.io/
 
 const {Command} = require('yuuko');
+const config = require('../../../config');
 const fetch = require('node-fetch');
 const convert = require('convert-units');
 
@@ -27,7 +28,7 @@ function convertUnits (baseValue, baseType, targetType) {
 async function convertCurrency (baseValue, baseType, targetType) {
 	baseType = baseType.toUpperCase();
 	targetType = targetType.toUpperCase();
-	const res = await fetch(`https://api.exchangeratesapi.io/latest?base=${baseType}&symbols=${targetType}`);
+	const res = await fetch(`http://api.exchangeratesapi.io/latest?access_key=${config.thirdParty.exchangeRates}&base=${baseType}&symbols=${targetType}`);
 	if (res.status !== 200) {
 		throw new Error('non-OK status code');
 	}
@@ -78,8 +79,8 @@ module.exports = new Command('convert', async (msg, args, context) => {
 		try {
 			// if it can't convert it normally, try to find it as a currency, throws if it can't find a currency either
 			message = await convertCurrency(baseValue, baseType, targetType);
-		} catch (__) {
-			message = `Couldn't convert from ${baseValue} ${baseType} to ${baseValue}. Type \`${context.prefix}convert\` to see all available units.`;
+		} catch (error) {
+			message = `Couldn't convert from ${baseValue} ${baseType} to ${targetType}. Type \`${context.prefix}convert\` to see all available units.`;
 		}
 	}
 

--- a/sample.config.js
+++ b/sample.config.js
@@ -45,4 +45,9 @@ module.exports = {
 		// 	certPath: '',
 		// },
 	},
+
+	// Third party APIs for command functionality
+	thirdParty: {
+		exchangeRates: '',
+	},
 };

--- a/sample.config.js
+++ b/sample.config.js
@@ -48,6 +48,7 @@ module.exports = {
 
 	// Third party APIs for command functionality
 	thirdParty: {
+		// https://exchangeratesapi.io
 		exchangeRates: '',
 	},
 };


### PR DESCRIPTION
- Updated .convert command to use an API key. It must also use HTTP instead of HTTPS now, due to us using the free plan.

- Fixed the error message not specifying the conversion types properly.

- Added the necessary section for third-party APIs in our config sample.