### PR TITLE
eris@0.15, yuuko@2.2

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -19,6 +19,10 @@ module.exports = (mongoClient, db) => {
 		// see https://github.com/discord/discord-api-docs/issues/2111 for alternatives
 		// #76
 		getAllUsers: true,
+		// TODO: Remove when Eris is updated and this becomes default behavior
+		rest: {
+			decodeReasons: false,
+		},
 	});
 
 	// Log on notable events

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bulma": "^0.9.0",
     "connect-mongo": "^3.2.0",
     "convert-units": "^2.3.4",
-    "eris": "^0.13.1",
+    "eris": "^0.15.0",
     "express-session": "^1.17.0",
     "mongodb": "^3.5.5",
     "node-fetch": "^2.6.1",
@@ -26,7 +26,7 @@
     "vue": "^2.6.11",
     "vue-router": "^3.3.4",
     "vuex": "^3.5.1",
-    "yuuko": "^2.1.0"
+    "yuuko": "^2.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,14 +1774,14 @@ envinfo@^7.7.3:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.4.tgz#c6311cdd38a0e86808c1c9343f667e4267c4a320"
   integrity sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==
 
-eris@^0.13.1:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/eris/-/eris-0.13.3.tgz#22abb71f9ce0d453200b537cad457dc39c7b302b"
-  integrity sha512-WBtLyknOWZpYZL9yPhez0oKUWvYpunSg43hGxawwjwSf3gFXmbEPYrT8KlmZXtpJnX16eQ7mzIq+MgSh3LarEg==
+eris@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/eris/-/eris-0.15.0.tgz#d0744d993d508b2951bc6d0ab380ae39b63c0666"
+  integrity sha512-muBdi5XyMXdxFQ8xUG6yofq40/Z02CHlqJP7zIdHhpdDiHvFM/mybGiFAHuoSYcsVTTvEfbUaAJ+SDEmMjARYw==
   dependencies:
     ws "^7.2.1"
   optionalDependencies:
-    opusscript "^0.0.7"
+    opusscript "^0.0.8"
     tweetnacl "^1.0.1"
 
 es-module-lexer@^0.4.0:
@@ -2858,10 +2858,10 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-opusscript@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/opusscript/-/opusscript-0.0.7.tgz#7dd7ec55b302d26bf588e6fc3feb090b8c7da856"
-  integrity sha512-DcBadTdYTUuH9zQtepsLjQn4Ll6rs3dmeFvN+SD0ThPnxRBRm/WC1zXWPg+wgAJimB784gdZvUMA57gDP7FdVg==
+opusscript@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/opusscript/-/opusscript-0.0.8.tgz#00b49e81281b4d99092d013b1812af8654bd0a87"
+  integrity sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -3902,7 +3902,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-yuuko@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/yuuko/-/yuuko-2.1.0.tgz#64b8e0b89e1110faeb04c2e04d515f69b3c2f2d5"
-  integrity sha512-WhkUL1vq5KSpRpGZpb+YlJAPRblrFlSB3JYe3c/23xkBiN829BmyiQ3rCgqrGSFGeLNekZbFX2fB01FXsjFAjA==
+yuuko@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/yuuko/-/yuuko-2.2.0.tgz#998bfb340c9d00b6aba9ebadb644e0b2e2aad874"
+  integrity sha512-4AHrTJqHmzJdXc6OHmefZ4X7jXviPNakH1kSF+ySOLC5tlZAeGj3NJJIEGDVlCtf1cIjwWfx9ACKtBpIBjK6gg==


### PR DESCRIPTION
Bumps Eris/Yuuko versions. Eris 0.15 introduces an option to disabling legacy handling of audit log reasons, which fixes a bug that prevented bans from going through with audit log reasons that contained special characters.