### PR TITLE
Handle Eris 0.14's new reaction user arg type

### DIFF
--- a/bot/util/discord.js
+++ b/bot/util/discord.js
@@ -13,10 +13,10 @@ module.exports = {
 		// TODO: use a single listener for this rather than adding and removing, this will not scale well
 		const client = message.channel.guild ? message.channel.guild._client : message.channel._client;
 		return new Promise((resolve, reject) => {
-			function reactionListener (reactedMessage, reactedEmote, reactedUserID) {
+			function reactionListener (reactedMessage, reactedEmote, reactingMember) {
 				// reaction has to be on the message we sent, by the user who sent the command, with the same emoji
 				if (reactedMessage.id !== message.id) return;
-				if (reactedUserID !== userID) return;
+				if (reactingMember.id !== userID) return;
 				if (reactedEmote.name !== emote && reactedEmote.id !== emote) return;
 				client.removeListener('messageReactionAdd', reactionListener);
 				resolve();


### PR DESCRIPTION
Eris 0.14 included a breaking change where some events that previously included user ID arguments now include a possibly uncached user/member object instead. This was not handled properly in #116 - I upgraded from Eris 0.13 straight to 0.15, and forgot to read the breaking change list from 0.14.