### PR TITLE
Fix RSS feeds

### DIFF
--- a/bot/events/rssFeeds.js
+++ b/bot/events/rssFeeds.js
@@ -49,22 +49,30 @@ module.exports = new EventListener('ready', ({client, db}) => {
 			log.debug('Checked feeds.');
 
 			// check every post, if it was posted after the latest check for this feed, post it in a channel
+			// Also keep track of the latest date of the items we process so we don't try to process them again
+			let latestDate = storedFeed.lastCheck;
 			for (const post of rssFeed.items) {
-				if (Date.parse(post.isoDate) > Date.parse(storedFeed.lastCheck)) {
-					const embed = buildRssEmbed(post.title, post.author, new Date(post.isoDate), 0xFF4401, storedFeed.url);
+				const itemDate = Date.parse(post.isoDate);
+				// If this item is from after the last check, process it
+				if (itemDate > storedFeed.lastCheck) {
+					const embed = buildRssEmbed(post.title, post.author, itemDate, 0xFF4401, storedFeed.url);
 					client.getChannel(storedFeed.channelId).createMessage({content: post.link, embed}).catch(error => {
 						log.error('Failed to post feed in RSS Feed event.', error);
 					});
 					// TODO: Here we can check the DB to know if anything in post.title matches a channel name
 					// and if so post it there, but that has to be mapped by a human because channel names can get weird
 				}
+				// Check if this is the latest post we've seen yet
+				if (itemDate > latestDate) {
+					latestDate = itemDate;
+				}
 			}
 
-			// update the DB with the date of the last post we checked.
+			// update the DB with the date of the latest post we found
 			const query = {name: storedFeed.name};
 			const update = {
 				$set: {
-					lastCheck: new Date(rssFeed.items[0].isoDate),
+					lastCheck: latestDate,
 				},
 			};
 			await collection.updateOne(query, update, {upsert: false}).catch(error => log.error('Failed to update document in feed event:', error));


### PR DESCRIPTION
Bug was caused by an incorrect assumption about Reddit's RSS feeds - they have stickies at the top so the first item can't be trusted to be the latest. We now compare the timestamps of all items in the feed when processing; it's also now impossible to write a time back earlier than the one already present in the database. Also some other cleanup - standardized on `new Date()` rather than `Date.parse()` for date comparisons to keep things a bit simpler.