### PR TITLE
Change up RSS embeds

### DIFF
--- a/bot/events/rssFeeds.js
+++ b/bot/events/rssFeeds.js
@@ -5,10 +5,7 @@ const rssParser = new Parser();
 
 /**
  * Builds an embed object to use when posting a feed.
- * @param {string} title The title of the embed.
- * @param {string} author  The author of the content in the embed.
- * @param {Date} date The date the content was made available.
- * @param {number} color The color of the embed frame.
+ * @param {object} post The parsed feed entry to generate an embed for.
  * @param {string} url The URL of the source of the content.
  * @returns {object}
  */


### PR DESCRIPTION
Use footer image instead of thumbnail for Reddit logo, include post URL as embed title link, display timestamp in `timestamp` field for relative date display, more robust URL checking for Reddit links that can be expanded to other services in the future if we want.

Not sure what's up with the `thumbnail` field but it doesn't seem to display nicely - this should fix title text being shoved all the way to the left like [that](https://discord.com/channels/267799767843602452/283592211986382849/855499495198425108).