### PR TITLE
Guard against periodic action failures

### DIFF
--- a/bot/events/reactionRoles.js
+++ b/bot/events/reactionRoles.js
@@ -20,11 +20,17 @@ function findReactConfig (message, emoji) {
 
 module.exports = new EventListener('ready', ({client, db}) => {
 	// Refresh the list of reaction roles every 30 seconds
-	(async function fetchReactionRoles () {
+	async function fetchReactionRoles () {
 		reactionRoles = await db.collection('reactionRoles').find({}).toArray();
 		log.debug('Reaction roles:', reactionRoles);
-		setTimeout(fetchReactionRoles, 30 * 1000);
-	})();
+	}
+	setInterval(() => {
+		if (client.ready) {
+			fetchReactionRoles().catch(log.error);
+		} else {
+			log.warn('Client disconnected while trying to get reaction roles; skipping');
+		}
+	}, 30 * 1000);
 
 	// Handle incoming reactions
 	// TODO: eventually yuuko will support exporting multiple event listeners from a single file - do that instead of\


### PR DESCRIPTION
Having a function call itself after execution ensures that it won't be queued until after it's done, which is nice, but it relies on the function getting that far in order to execute itself again. If there are errors in execution, it will end the loop, which is a bad time. This PR swaps these things to use `setInterval` instead in order to ensure they'll keep happening even if one run fails. It also adds catch-all logging and a check for the client's connection state before trying to do things against the Discord API, which I have a feeling might be part of why things were breaking before.