### PR TITLE
Relative timestamps

### DIFF
--- a/src/bot/commands/moderation/ban.js
+++ b/src/bot/commands/moderation/ban.js
@@ -1,7 +1,7 @@
 import createLogger from 'another-logger';
 const log = createLogger({label: 'command:ban'});
 import {Command} from 'yuuko';
-import {parseUser, parseTime, formatDateTime, awaitReaction} from '../../util/discord';
+import {parseUser, parseTime, formatDateRelative, awaitReaction} from '../../util/discord';
 import {escape, blockquote} from '../../util/formatting';
 
 const confirmationEmoji = '🔨';
@@ -14,7 +14,7 @@ const confirmationEmoji = '🔨';
  * @returns {string}
  */
 function banMessage (guild, reason, expirationDate) {
-	return `You've been banned from __${escape(guild.name)}__ ${expirationDate ? `until ${formatDateTime(expirationDate)}` : 'permanently'}.\n${reason ? blockquote(escape(reason)) : ''}`;
+	return `You've been banned from __${escape(guild.name)}__ ${expirationDate ? `and will be unbanned ${formatDateRelative(expirationDate)}` : 'permanently'}.\n${reason ? blockquote(escape(reason)) : ''}`;
 }
 
 const command = new Command('ban', async (message, args, context) => {
@@ -93,7 +93,7 @@ const command = new Command('ban', async (message, args, context) => {
 		return;
 	}
 
-	message.channel.createMessage(`Banned <@${user.id}> ${duration ? `until ${formatDateTime(expirationDate)}` : 'permanently'}.${messageSent ? '' : ' Failed to send notification because of privacy settings.'}`).catch(() => {});
+	message.channel.createMessage(`Banned <@${user.id}> ${duration ? `to be unbanned ${formatDateRelative(expirationDate)}` : 'permanently'}.${messageSent ? '' : ' Failed to send notification because of privacy settings.'}`).catch(() => {});
 }, {
 	permissions: [
 		'banMembers',

--- a/src/bot/util/discord.js
+++ b/src/bot/util/discord.js
@@ -183,22 +183,22 @@ export function parseTime (str) {
 // TODO: these require extra locales that don't come with node by default until 14, until that hits LTS these will produce US-looking dates
 
 /**
- * Wraps `toLocaleString` with consistent formatting.
+ * Formats a date and time using Discord's styled unix timestamp format.
  * @param {Date} date
  * @returns {string}
  */
-export const formatDateTime = date => `${date.toLocaleString('en-GB', {timeZone: 'UTC'})} UTC`;
+export const formatDateTime = date => `<t:${Math.round(date.getTime() / 1000)}:f>`;
 
 /**
- * Wraps `toLocaleDateString` with consistent formatting.
+ * Formats a date using Discord's styled unix timestamp format.
  * @param {Date} date
  * @returns {string}
  */
-export const formatDate = date => `${date.toLocaleDateString('en-GB', {timeZone: 'UTC'})} UTC`;
+export const formatDate = date => `<t:${Math.round(date.getTime() / 1000)}:d>`;
 
 /**
- * Wraps `toLocaleTimeString` with consistent formatting.
+ * Formats a time using Discord's styled unix timestamp format.
  * @param {Date} date
  * @returns {string}
  */
-export const formatTime = date => `${date.toLocaleTimeString('en-GB', {timeZone: 'UTC'})} UTC`;
+export const formatTime = date => `<t:${Math.round(date.getTime() / 1000)}:t>`;

--- a/src/bot/util/discord.js
+++ b/src/bot/util/discord.js
@@ -202,3 +202,10 @@ export const formatDate = date => `<t:${Math.round(date.getTime() / 1000)}:d>`;
  * @returns {string}
  */
 export const formatTime = date => `<t:${Math.round(date.getTime() / 1000)}:t>`;
+
+/**
+ * Formats a date/time using Discord's relative unix timestamp format.
+ * @param {Date} date
+ * @returns {string}
+ */
+export const formatDateRelative = date => `<t:${Math.round(date.getTime() / 1000)}:R>`;


### PR DESCRIPTION
Adds support for Discord's new `<t:TIMESTAMP[:FORMAT]>` date/time formatting. Not currently supported on all platforms; don't merge until this shows up correctly everywhere.